### PR TITLE
Deploy guides to github pages using Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+title: "Nomifactory Guides"
+remote_theme: pmarsceill/just-the-docs
+search_enabled: false


### PR DESCRIPTION
This does the bare minimum to just config the repo for gh-pages. See https://mrconnerton.github.io/Guides/ as an example with no other config. After merge, gh-pages would need to be enabled, and then ideally the existing guides updated with some frontmatter for organization.